### PR TITLE
【fixed】'rails g'のコマンドの際にassetsファイル、helperが作成されないように改善

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,11 @@ module Sample
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-
+    config.generators do |g|
+      # この二行の記述で自動生成しない設定を作成しています。
+      g.assets false
+      g.helper false
+    end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
#1 

・config/application.rbファイルに下記を記載した。

config.generators do |g|
      g.assets false
      g.helper false
    end